### PR TITLE
fix-prスキルを追加

### DIFF
--- a/plugins/base-tools/skills/fix-pr/SKILL.md
+++ b/plugins/base-tools/skills/fix-pr/SKILL.md
@@ -14,12 +14,11 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Bash(slee
 - [ ] ステップ3：CIの終了を待機する
 - [ ] ステップ4：CIの結果を詳細に把握する
 - [ ] ステップ5：レビューコメントを把握する
-- [ ] ステップ6：承認済み・outdated対応済みスレッドのresolveを行う
-- [ ] ステップ7：方針に従って対応を行う
-- [ ] ステップ8：完了条件を満たしているか確認する
-- [ ] ステップ9：Issueとの紐付けを確認する
-- [ ] ステップ10：マージ前にbehind状態を再確認する
-- [ ] ステップ11：PRのマージを行う
+- [ ] ステップ6：方針に従って対応を行う
+- [ ] ステップ7：完了条件を満たしているか確認する
+- [ ] ステップ8：Issueとの紐付けを確認する
+- [ ] ステップ9：マージ前にbehind状態を再確認する
+- [ ] ステップ10：PRのマージを行う
 
 1. プルリクエストの番号を特定する。
     - コマンド: `gh pr view --json number --jq '.number'`
@@ -35,43 +34,38 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Bash(slee
 4. CIの結果を確認する。
     - コマンド: `gh pr checks {PR番号}`
     - 一時的な問題（インフラ障害、flaky test等）の場合は `gh run rerun {run-id}` で再実行し、手順3に戻る。同一ワークフローの再実行は最大2回まで。
-    - コード修正が必要な場合は、対応方針を決めて手順7で修正する。
+    - コード修正が必要な場合は、対応方針を決めて手順6で修正する。
 5. レビューコメントを把握し、対応方針を決める。
     - コマンド: `gh api graphql -f query='query($owner:String!, $repo:String!, $number:Int!, $after:String) { repository(owner:$owner, name:$repo) { pullRequest(number:$number) { reviewThreads(first:100, after:$after) { pageInfo { hasNextPage endCursor } nodes { id isResolved isOutdated comments(first:100) { nodes { author { login } body } } } } } } }' -F owner='{OWNER}' -F repo='{REPO}' -F number={PR番号}`
     - `hasNextPage` が true の間は `-F after='{endCursor}'` を渡して繰り返し、全スレッドを取得する。
     - 改修提案かつ対応が必要: コード修正と返信
     - 改修提案かつ対応が不要: 理由を添えて返信
-    - 対応内容が承認された: Resolve
-    - IsOutdated=true かつ対応済み（コード修正・返信完了）: Resolve
-    - botレビュアーからのコメントかつ改修提案への対応済み（コード修正・返信完了）: Resolve
-6. 承認済みスレッド、outdated対応済みスレッド、およびbot対応済みスレッドを resolve する。
-    - コマンド: `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "{スレッドID}"}) { thread { id isResolved } } }'`
-7. 手順4と5で決めた方針に従って対応を行う。
+6. 手順4と5で決めた方針に従って対応を行う。
     - CI失敗への対応とレビューコメントへのコード修正をまとめて行い、コミット・プッシュする。
     - 各レビューコメントスレッドへ返信を行う。
         - コマンド: `gh api graphql -f query='mutation($threadId:ID!, $body:String!) { addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) { comment { id body } } }' -F threadId='{スレッドID}' -F body='{返信内容}'`
-8. 完了条件を満たしているか確認する。
+7. 完了条件を満たしているか確認する。
     - CIが未完了の場合は `gh pr checks {PR番号} --watch` を使用してCIの完了を待機してから手順2に戻る。
     - その他の条件を満たしていない場合は未完了の条件をユーザーに報告し、30秒待機してから手順2に戻る。
     - 手順2からの再実施は最大10回まで。10回を超えた場合は未完了の条件と試行内容をユーザーに報告し、続行するか判断を仰ぐ。
-9. Issueとの紐付けを確認する。
+8. Issueとの紐付けを確認する。
     - コマンド: `gh api graphql -f query='query { repository(owner:"{OWNER}", name:"{REPO}") { pullRequest(number:{PR番号}) { closingIssuesReferences(first:10) { nodes { number title } } } } }'`
-    - 紐付けがある場合は手順10へ進む。
+    - 紐付けがある場合は手順9へ進む。
     - 紐付けがない場合（`closingIssuesReferences` が空）、ユーザーに警告し、続行の承認を得る。
-    - ユーザーが続行を承認した場合は手順10へ進む。承認しない場合は作業を中断する。
-10. マージ前にbehind状態を再確認する。
+    - ユーザーが続行を承認した場合は手順9へ進む。承認しない場合は作業を中断する。
+9. マージ前にbehind状態を再確認する。
     - コマンド: `gh pr view {PR番号} --json mergeStateStatus --jq '.mergeStateStatus'`
     - behind状態が `null` の場合は10秒待機してから再取得する（最大3回まで）。
-    - behind状態が `BEHIND` の場合はベースブランチをマージし、手順3に戻る（手順8の回数制限の対象）。
-    - behind状態が `BEHIND` でない場合は手順11へ進む。
-11. PRのマージを行う。
+    - behind状態が `BEHIND` の場合はベースブランチをマージし、手順3に戻る（手順7の回数制限の対象）。
+    - behind状態が `BEHIND` でない場合は手順10へ進む。
+10. PRのマージを行う。
     - コマンド: `gh pr merge {PR番号}`
     - マージ方式はリポジトリのデフォルト設定に従う。
     - マージに成功した場合は完了をユーザーに報告する。
     - マージに失敗した場合、失敗理由を確認し以下の対応を行う：
-        - behind状態: ベースブランチをマージし、手順3に戻る（手順8の回数制限の対象）。
-        - マージコンフリクト: コンフリクトの解消を試み、解消できた場合はコミット・プッシュして手順3に戻る（手順8の回数制限の対象）。解消が困難な場合はコンフリクト箇所をユーザーに報告し、判断を仰ぐ。
-        - 必須チェック未通過: 手順3に戻りCIの完了を待機する（手順8の回数制限の対象）。
+        - behind状態: ベースブランチをマージし、手順3に戻る（手順7の回数制限の対象）。
+        - マージコンフリクト: コンフリクトの解消を試み、解消できた場合はコミット・プッシュして手順3に戻る（手順7の回数制限の対象）。解消が困難な場合はコンフリクト箇所をユーザーに報告し、判断を仰ぐ。
+        - 必須チェック未通過: 手順3に戻りCIの完了を待機する（手順7の回数制限の対象）。
         - 必須レビュー未承認: 未承認であることをユーザーに報告し、承認を待つか判断を仰ぐ。
         - 上記いずれにも該当しない場合: 失敗理由の詳細をユーザーに報告し、対処方法の判断を仰ぐ。
 
@@ -79,15 +73,10 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Bash(slee
 
 以下の全てを満たすこと：
 - [ ] PRブランチがベースブランチに対して遅れていない（behind状態でない）
-- [ ] outdatedのものも含め、レビュースレッドが全て resolve されている
 - [ ] 改修提案への対応が完了し、返信済み
 - [ ] 対応不要なコメントへの返信が完了している
 - [ ] CI が全て成功している
 
 ## 注意点
-- 承認されるまではResolveすることは禁止
-  - ただし、改修提案への対応済み（コード修正・返信完了）のスレッドは、以下の場合に例外としてResolve可能：
-    - `IsOutdated=true`である
-    - botレビュアーからのコメントである
 - 返信時はスレッドの投稿者全員に対してメンションすること
 - マージ後にブランチの自動削除は行わない


### PR DESCRIPTION
## 概要
base-toolsプラグインにfix-prスキルを追加します。
PRのCI状態確認、レビューコメント対応、マージまでの一連のワークフローを自動化するスキルです。

## 修正内容
- `plugins/base-tools/skills/fix-pr/SKILL.md` にfix-prスキルの手順を追加
  - PR番号の特定からマージまでの11ステップのワークフローを定義
  - CI待機・結果確認・再実行の手順
  - レビューコメントの把握・対応・返信・resolveの手順
  - behind状態の検知・ベースブランチマージの手順
  - Issue紐付け確認の手順
  - マージ失敗時の原因別自律対応（コンフリクト解消、CI待機等）
  - 完了条件と注意点（Resolveルール、メンションルール等）を明記

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * PR自動修正ワークフロー用の新しいスキルドキュメントを追加しました。日本語のステップ別チェックリスト、操作コマンド例、PRの特定から完了までの手順、CI待機と自動再試行、レビュー対応・スレッド解消、事前・事後の検証とマージ処理、完了条件と復旧手順、権限や返信・ブランチ運用に関する注意点を含みます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->