### PR TITLE
fix-prスキルのmergeStateStatus網羅的対応とbotレビュアーresolveポリシーを追加

### DIFF
--- a/plugins/base-tools/skills/fix-pr/SKILL.md
+++ b/plugins/base-tools/skills/fix-pr/SKILL.md
@@ -28,6 +28,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Bash(slee
     - 状態別の対応：
         - `BEHIND`: PRブランチへ checkout し、作業ツリーがクリーンであることを確認してからベースブランチをマージする。
             - 事前確認: `gh pr checkout {PR番号}` でPRブランチへ移動し、`git status --porcelain` が空であることを確認する。
+            - 作業ツリーが clean でない場合: 未コミットの変更をユーザーに報告し、続行方法の判断を仰ぐ。
             - コマンド: `gh pr view {PR番号} --json baseRefName --jq '.baseRefName'` でベースブランチ名を取得し、`git fetch origin {ベースブランチ} && git merge origin/{ベースブランチ}` でマージする。
         - `DIRTY`: コンフリクトが存在する。PRブランチへ checkout しベースブランチをマージしてコンフリクト解消を試みる。解消が困難な場合はコンフリクト箇所をユーザーに報告し、判断を仰ぐ。
         - `BLOCKED`: 必須チェックまたは必須レビューが未完了。手順3へ進む。


### PR DESCRIPTION
## Summary
- ステップ2,9: `mergeStateStatus` の全状態（`BLOCKED`, `CLEAN`, `DIRTY`, `DRAFT`, `UNSTABLE`, `HAS_HOOKS`, `UNKNOWN`）への状態別ルーティングを追加
- ステップ5: レビュースレッドの `isResolved`/`isOutdated` フィルタリングと bot レビュアー識別基準を追加
- ステップ5,6: bot レビュアーは `resolveReviewThread` で resolve、人間のレビュアーは返信のみとする resolve ポリシーを追加
- 完了条件を `mergeStateStatus` ベースに変更し、レビュー関連条件を統合

Closes #11

## Test plan
- [ ] 実際の PR で `/fix-pr` を実行し、`mergeStateStatus` が `BLOCKED`/`CLEAN` 等の場合に適切にルーティングされることを確認
- [ ] bot レビュアーのスレッドが対応後に resolve されることを確認
- [ ] 人間のレビュアーのスレッドが resolve されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * PR修正スキルのプロセス文書を大幅更新：マージ状態を複数ステータスで扱う詳細フロー、ステータス別の事前チェックとリトライ手順、CI/レビュースレッド処理の明確化、マージ失敗時の回復・再試行ガイドを追加しました。
  * レビュースレッドのフィルタリング改善と、ボットによるスレッド自動解決ポリシーを明示しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->