### PR TITLE
retroスキルを追加

### DIFF
--- a/plugins/base-tools/skills/retro/SKILL.md
+++ b/plugins/base-tools/skills/retro/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(gh:*)
     - 些細な修正（誤字脱字）: ユーザー確認の上で直接修正
     - それ以外: GitHub Issue作成（作成前に重複チェック）
         1. 作成予定タイトルで類似Issueを検索する
-            - コマンド: `gh issue list --state open --search "{検索キーワード}"`
+            - コマンド: `gh issue list --state all --search "{検索キーワード}"`
         2. 類似Issueがある場合: 作成をスキップし、既存IssueのタイトルとURLを表示
         3. 類似Issueがない場合: Issueを作成する
             - コマンド: `gh issue create --title "{タイトル}" --body "{本文}"`


### PR DESCRIPTION
## 概要

作業セッションの振り返りを行い、`.claude/`配下の設定改善点を分析してGitHub Issueを作成するretroスキルを追加します。

## 修正内容

- `plugins/base-tools/skills/retro/SKILL.md` を新規作成
  - 会話セッションの振り返り手順を定義
  - `.claude/`配下の設定ファイルとのギャップ分析
  - 改善点のGitHub Issue作成（重複チェック付き）
  - 些細な修正の直接対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 新しいスキルガイド「retro」を追加：セッション後の設定見直しワークフロー、タスク振り返りと設定比較の手順、改善案の分類（軽微修正は確認で対応、重要な変更はIssue作成）、既存Issueの検索と新規Issue作成時の要点、改善が不要な場合の報告方法などを説明します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->