### PR TITLE
fix-prスキルのマージコマンドを非対話モードに対応させる

### DIFF
--- a/plugins/base-tools/skills/fix-pr/SKILL.md
+++ b/plugins/base-tools/skills/fix-pr/SKILL.md
@@ -115,6 +115,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Bash(slee
 10. PRのマージを行う。
     - リポジトリで許可されているマージ方式を確認する。
         - コマンド: `gh api repos/{OWNER}/{REPO} --jq '{squash: .allow_squash_merge, merge: .allow_merge_commit, rebase: .allow_rebase_merge}'`
+        - API呼び出しに失敗した場合（権限不足、ネットワークエラー等）: エラー内容をユーザーに報告し、作業を中断する。
     - 以下の優先順位でマージ方式を選択し、対応するフラグを使用する：
         1. squash merge が許可されている場合: `--squash`
         2. merge commit が許可されている場合: `--merge`


### PR DESCRIPTION
## 概要
fix-prスキルのステップ10で使用している `gh pr merge` コマンドが、非対話モードでマージ方式フラグ未指定エラーになる問題を修正します。リポジトリの許可設定を確認し、適切なマージ方式フラグを明示的に指定するようにしました。

## 関連Issue
Fixes: #14

## 修正内容
- ステップ10のマージコマンドを変更:
  - `gh api` でリポジトリの許可されたマージ方式（squash/merge/rebase）を確認する手順を追加
  - squash > merge > rebase の優先順位でマージ方式を選択するロジックを追加
  - `gh pr merge {PR番号} {選択したマージ方式フラグ}` の形式でフラグを明示的に指定するよう変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * PR マージ時にリポジトリで許可されたマージ方法を確認し、優先度（スクワッシュ > マージ > リベース）で最適な方法を自動選択して適用するようになりました。
* **バグ修正**
  * マージ失敗時の判定とメッセージを改善し、競合やブロック状況などに対する挙動を明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->