### PR TITLE
git worktree管理スキルの作成

### DIFF
--- a/plugins/base-tools/skills/setup-worktree/SKILL.md
+++ b/plugins/base-tools/skills/setup-worktree/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: setup-worktree
+description: 指定されたブランチ名でgit worktreeを作成し、作業ディレクトリを切り替えます。`/setup-worktree {ブランチ名}` で使用してください。
+argument-hint: "[branch-name]"
+allowed-tools: Bash(git:*), Bash(mkdir:*), Bash(cd:*), Bash(pwd:*), Bash(test:*)
+---
+
+## 手順
+
+1. **引数確認**: `$ARGUMENTS` からブランチ名を取得する。未指定の場合はユーザーに報告し、作業を中断する。
+
+2. **リポジトリ情報取得**: プロジェクトルートを取得する。
+    - コマンド: `git rev-parse --show-toplevel`
+
+3. **パス決定**: worktree パスを算出する。
+    - プロジェクト名を `basename` で取得する。
+    - ブランチ名のスラッシュをハイフンに変換する（`tr '/' '-'`）。
+    - worktree パス: `{プロジェクトルート}/../{プロジェクト名}.worktrees/{変換後ブランチ名}`
+    - 例: プロジェクトルートが `/workspaces/claude-code-plugins`、ブランチ名が `feature/issue-42` の場合
+      - worktree パス: `/workspaces/claude-code-plugins.worktrees/feature-issue-42`
+
+4. **事前チェック**:
+    - worktree パスが既に存在するか確認する（`test -d`）。
+    - 既存の有効な worktree の場合（`git worktree list` に含まれる場合）: そのままステップ7へ進む（ユーザー確認不要）。
+    - ディレクトリは存在するが worktree でない場合: ユーザーに報告し、作業を中断する。
+    - ブランチがリモートに存在するか確認する（`git branch -r --list "origin/{ブランチ名}"`）。
+
+5. **新規ブランチでworktree作成**（ブランチがリモートに存在しない場合）:
+    ```bash
+    PROJECT_ROOT=$(git rev-parse --show-toplevel)
+    PROJECT_NAME=$(basename "${PROJECT_ROOT}")
+    WORKTREE_BASE="${PROJECT_ROOT}/../${PROJECT_NAME}.worktrees"
+    mkdir -p "${WORKTREE_BASE}"
+    git fetch origin main
+    git worktree add -b "{ブランチ名}" "${WORKTREE_PATH}" origin/main
+    ```
+
+6. **既存ブランチでworktree作成**（ブランチがリモートに存在する場合）:
+    ```bash
+    mkdir -p "${WORKTREE_BASE}"
+    git fetch origin "{ブランチ名}"
+    git worktree add "${WORKTREE_PATH}" "{ブランチ名}"
+    ```
+
+7. **作業ディレクトリ切替**: worktree に移動し、状態を確認・報告する。
+    - コマンド: `cd "${WORKTREE_PATH}"` → `pwd` と `git branch --show-current` で確認する。
+
+## 完了条件
+
+以下の全てを満たすこと：
+- [ ] worktree が作成されている（または既存 worktree に移動している）
+- [ ] 作業ディレクトリが worktree に切り替わっている
+- [ ] `git branch --show-current` が指定ブランチを示している

--- a/plugins/base-tools/skills/solve-issue/SKILL.md
+++ b/plugins/base-tools/skills/solve-issue/SKILL.md
@@ -3,7 +3,7 @@ name: solve-issue
 description: GitHub Issueの内容を把握し、実装・コミット・自己レビュー・PR作成・マージまでを一貫して行います。`/solve-issue {Issue番号}` で使用してください。
 argument-hint: "[issue-number]"
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(create-pr), Skill(fix-pr), Skill(retro)
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(setup-worktree), Skill(create-pr), Skill(fix-pr), Skill(teardown-worktree), Skill(retro)
 ---
 
 ## 手順
@@ -12,14 +12,15 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(cre
 
 タスク進捗：
 - [ ] ステップ1：Issueの内容を把握する
-- [ ] ステップ2：作業ブランチを作成する
+- [ ] ステップ2：/setup-worktree でworktreeを作成する
 - [ ] ステップ3：実装を行う
 - [ ] ステップ4：コミットする
 - [ ] ステップ5：自己レビューを行う
 - [ ] ステップ6：レビュー指摘を修正する
 - [ ] ステップ7：/create-pr を実行する
 - [ ] ステップ8：/fix-pr を実行する
-- [ ] ステップ9：/retro を実行する
+- [ ] ステップ9：/teardown-worktree でworktreeを削除する
+- [ ] ステップ10：/retro を実行する
 
 1. Issueの内容を把握する。
     - 引数 `$ARGUMENTS` からIssueの詳細を取得する。
@@ -29,11 +30,11 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(cre
     - Issueの内容（タイトル、本文、ラベル等）から実装要件を整理する。
     - 要件が不明確な場合はユーザーに確認する。
 
-2. 作業ブランチを作成する。
-    - 現在のブランチが `main` の場合、Issue内容に基づいたブランチ名で新しいブランチを作成する。
+2. `/setup-worktree` でworktreeを作成する。
+    - 現在のブランチが `main` の場合、Issue内容に基づいたブランチ名を決定する。
     - ブランチ名の形式: `feature/issue-{Issue番号}-{簡潔な説明}`（例: `feature/issue-42-add-login`）
-    - コマンド: `git checkout -b {ブランチ名}`
-    - 現在のブランチが `main` 以外の場合、そのブランチで作業を続行するかユーザーに確認する。
+    - setup-worktree スキルを呼び出してworktreeを作成し、作業ディレクトリを切り替える。
+    - 現在のブランチが `main` 以外の場合、そのブランチで作業を続行するかユーザーに確認する（worktree作成はスキップ）。
 
 3. 実装を行う。
     - Issueの要件に基づいてコードの修正・追加を行う。
@@ -71,7 +72,11 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(cre
 8. `/fix-pr` を実行する。
     - fix-pr スキルを呼び出してCI確認・レビュー対応・マージを行う。
 
-9. `/retro` を実行する。
+9. `/teardown-worktree` でworktreeを削除する。
+    - teardown-worktree スキルを呼び出してworktreeを削除し、元のリポジトリに戻る。
+    - ステップ2でworktree作成をスキップした場合は、このステップもスキップする。
+
+10. `/retro` を実行する。
     - retro スキルを呼び出して作業セッションの振り返りを行う。
 
 ## 完了条件
@@ -81,6 +86,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(cre
 - [ ] 自己レビューで問題が検出されていない（または全て修正済み）
 - [ ] プルリクエストが作成されている
 - [ ] PRがマージされている
+- [ ] worktreeが削除され、元のリポジトリに作業ディレクトリが戻っている（worktreeを使用した場合）
 - [ ] retro が実行されている
 
 ## 注意点
@@ -88,3 +94,4 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(cre
 - 大規模な変更が必要な場合は、実装前にユーザーに方針を提示して承認を得ること
 - Issueに記載のない追加改善は行わず、Issueのスコープに集中すること
 - コミットメッセージにはIssue番号を含め、トレーサビリティを確保すること
+- worktreeでの作業中は cd で元のリポジトリに戻らないこと

--- a/plugins/base-tools/skills/teardown-worktree/SKILL.md
+++ b/plugins/base-tools/skills/teardown-worktree/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: teardown-worktree
+description: 現在のworktreeを削除し、元のリポジトリに作業ディレクトリを戻します。worktreeでの作業が完了した際に使用してください。
+allowed-tools: Bash(git:*), Bash(cd:*), Bash(pwd:*)
+---
+
+## 手順
+
+1. **worktree判定**: 現在メインリポジトリにいるか確認する。
+    - `git worktree list` の最初の行（メインリポジトリ）と `git rev-parse --show-toplevel` を比較する。
+    - メインリポジトリにいる場合はユーザーに報告し、作業を中断する。
+
+2. **メインリポジトリパス取得**: `git worktree list --porcelain` の最初のエントリからメインリポジトリのパスを取得する。
+
+3. **未コミット変更チェック**: `git status --porcelain` で未コミットの変更がないか確認する。
+    - 変更がある場合はユーザーに判断を仰ぐ（破棄 / コミット / 中断）。
+
+4. **worktreeパス記録**: 現在の worktree パスを記録する。
+    - コマンド: `WORKTREE_PATH=$(git rev-parse --show-toplevel)`
+
+5. **メインリポジトリへ移動**: 削除前にメインリポジトリへ移動する。
+    - コマンド: `cd "${MAIN_REPO_PATH}"`
+    - カレントディレクトリが削除対象の worktree 内にあると削除に失敗するため、必ず先に移動する。
+
+6. **worktree削除**: worktree を削除する。
+    - コマンド: `git worktree remove "${WORKTREE_PATH}"`
+    - ステップ3で変更の破棄を選択した場合は `--force` オプションを付与する。
+
+7. **削除確認**: 削除結果を確認・報告する。
+    - コマンド: `git worktree list` と `pwd` で確認する。
+
+## 完了条件
+
+以下の全てを満たすこと：
+- [ ] worktree が `git worktree list` に表示されていない
+- [ ] 作業ディレクトリが元のリポジトリに戻っている
+
+## 注意点
+- ブランチの削除は行わない（PR マージ後に GitHub が自動削除する場合がある）
+- カレントディレクトリを削除しないよう、必ず先にメインリポジトリへ `cd` する


### PR DESCRIPTION
## 概要

複数のエージェントが同一リポジトリで並行作業する際の作業ディレクトリ競合を防止するため、git worktreeを活用するスキルを新規作成し、solve-issueスキルに統合しました。

## 関連Issue
Fixes: #23

## 修正内容

- **setup-worktreeスキルを新規作成**
  - 指定ブランチ名でgit worktreeを作成し、作業ディレクトリを切り替える
  - worktreeパス規約: `{プロジェクトルート}/../{プロジェクト名}.worktrees/{ブランチ名}`
  - 新規/既存ブランチの自動判定、既存worktreeの再利用に対応
- **teardown-worktreeスキルを新規作成**
  - 現在のworktreeを削除し、元のリポジトリに作業ディレクトリを戻す
  - 未コミット変更の検出とユーザー確認、安全な削除手順
- **solve-issueスキルをworktreeワークフローに対応**
  - ステップ2: ブランチ作成 → `/setup-worktree` に変更
  - ステップ9: `/teardown-worktree` によるworktree削除を追加
  - allowed-tools、チェックリスト、完了条件、注意点を更新

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Git worktreeの作成と管理のための新しいワークフロー機能を追加しました。

* **ドキュメント**
  * worktree作成スキルの使用方法を文書化しました。
  * worktree削除スキルの使用方法を文書化しました。
  * ワークフローにworktree対応の手順を統合しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->