### PR TITLE
solve-issue: 作業ブランチにいる場合はsetup-worktreeをスキップする (#35)

### DIFF
--- a/plugins/base-tools/skills/solve-issue/SKILL.md
+++ b/plugins/base-tools/skills/solve-issue/SKILL.md
@@ -34,7 +34,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(set
     - 現在のブランチが `main` の場合、Issue内容に基づいたブランチ名を決定する。
     - ブランチ名の形式: `feature/issue-{Issue番号}-{簡潔な説明}`（例: `feature/issue-42-add-login`）
     - setup-worktree スキルを呼び出してworktreeを作成し、作業ディレクトリを切り替える。
-    - 現在のブランチが `main` 以外の場合、そのブランチで作業を続行するかユーザーに確認する（worktree作成はスキップ）。
+    - 現在のブランチが `main` 以外の場合、ユーザー確認なしでworktree作成をスキップし、現在のブランチでそのまま作業を続行する。
 
 3. 実装を行う。
     - Issueの要件に基づいてコードの修正・追加を行う。


### PR DESCRIPTION
## 概要

`/solve-issue` コマンドのステップ2で、`main` 以外のブランチにいる場合にユーザー確認なしで `setup-worktree` をスキップし、現在のブランチでそのまま作業を続行するように変更します。

Claude Code on the web などの環境では作業ブランチが自動的に作成されるため、毎回ユーザーに確認するのは冗長でした。

## 関連Issue

Closes: #35

## 修正内容

- `plugins/base-tools/skills/solve-issue/SKILL.md` のステップ2の記述を変更
  - 変更前：「現在のブランチが `main` 以外の場合、そのブランチで作業を続行するかユーザーに確認する（worktree作成はスキップ）」
  - 変更後：「現在のブランチが `main` 以外の場合、ユーザー確認なしでworktree作成をスキップし、現在のブランチでそのまま作業を続行する」

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 非メインブランチでの動作を改善。ユーザー確認なしに自動的にワークツリー作成をスキップし、現在のブランチで作業を継続するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->