### PR TITLE
feat(skill): solve-issueのIssue確認ステップにコメント取得を追加

### DIFF
--- a/plugins/base-tools/skills/solve-issue/SKILL.md
+++ b/plugins/base-tools/skills/solve-issue/SKILL.md
@@ -27,7 +27,10 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Skill(set
     - コマンド: `gh issue view $ARGUMENTS --json number,title,body,labels,assignees,milestone,state`
     - Issueが存在しない場合はユーザーに報告し、作業を中断する。
     - Issueが closed の場合はユーザーに報告し、続行するか判断を仰ぐ。
-    - Issueの内容（タイトル、本文、ラベル等）から実装要件を整理する。
+    - Issueのコメントを取得する。
+    - コマンド: `gh issue view $ARGUMENTS --comments`
+    - コメントにはオーナーやコントリビューターからの方針決定や要件の補足が含まれることがあるため、必ず確認する。
+    - Issueの内容（タイトル、本文、ラベル、コメント等）から実装要件を整理する。
     - 要件が不明確な場合はユーザーに確認する。
 
 2. `/setup-worktree` でworktreeを作成する。


### PR DESCRIPTION
## 概要

solve-issueスキルのステップ1（Issueの内容を把握する）で、Issue本文のみ取得しコメントを確認していなかったため、コメントに記載された方針や追加情報を見落とす可能性がありました。
ステップ1にコメント取得コマンドを追加し、コメントの内容も要件整理に含めるようにしました。

## 関連Issue
Closes: #29

## 修正内容
- ステップ1に `gh issue view $ARGUMENTS --comments` によるコメント取得手順を追加
- コメントに方針決定や要件の補足が含まれる可能性がある旨の注意書きを追加
- 要件整理の対象に「コメント」を明記

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * イシュー処理時にコメントが検討対象に追加されました。オーナーや貢献者による決定や要件がコメントに含まれている場合、それらが自動的に確認され、実装要件の生成に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->