### PR TITLE
fix(skill): fix-prのIssue紐付け確認でユーザー承認を省略する

### DIFF
--- a/plugins/base-tools/skills/fix-pr/SKILL.md
+++ b/plugins/base-tools/skills/fix-pr/SKILL.md
@@ -100,9 +100,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Bash(slee
         }
         EOF
         ```
-    - 紐付けがある場合は手順9へ進む。
-    - 紐付けがない場合（`closingIssuesReferences` が空）、ユーザーに警告し、続行の承認を得る。
-    - ユーザーが続行を承認した場合は手順9へ進む。承認しない場合は作業を中断する。
+    - 紐付けの有無に関わらず手順9へ進む。
 9. マージ前に `mergeStateStatus` を再確認する。
     - コマンド: `gh pr view {PR番号} --json mergeStateStatus --jq '.mergeStateStatus'`
     - 状態別の対応：


### PR DESCRIPTION
## 概要

`/fix-pr` スキル実行時、PRにIssueの紐付けがない場合（`closingIssuesReferences` が空）にユーザーへ警告・承認を求める処理を削除し、紐付けの有無に関わらずマージに進むように変更しました。

## 関連Issue

Closes #32

## 修正内容

- `plugins/base-tools/skills/fix-pr/SKILL.md` のステップ8を修正
  - 紐付けがある場合/ない場合の条件分岐を削除
  - 「紐付けの有無に関わらず手順9へ進む」に簡略化

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善（Refactor）**
  - PR修正ワークフローを簡素化しました。issue参照がない場合の不要なユーザー確認ステップが削除され、プロセスがより効率的に進行するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->