### PR TITLE
fix(skill): fix-prのBLOCKED状態でreviewDecisionを確認しレビュー承認待ちを早期判別

### DIFF
--- a/plugins/base-tools/skills/fix-pr/SKILL.md
+++ b/plugins/base-tools/skills/fix-pr/SKILL.md
@@ -33,7 +33,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(slee
         - `DIRTY`: コンフリクトが存在する。PRブランチへ checkout しベースブランチをマージしてコンフリクト解消を試みる。解消が困難な場合はコンフリクト箇所をユーザーに報告し、判断を仰ぐ。
         - `BLOCKED`: 必須チェックまたは必須レビューが未完了。
             - `gh pr view {PR番号} --json reviewDecision --jq '.reviewDecision'` で確認する。
-            - `REVIEW_REQUIRED` の場合: レビュー承認が必要であることをユーザーに報告し、承認を待つか判断を仰ぐ。
+            - `REVIEW_REQUIRED` または `CHANGES_REQUESTED` の場合: レビュー承認が必要、または変更が要求されていることをユーザーに報告し、対応を待つか判断を仰ぐ。
             - それ以外の場合: 手順3へ進む。
         - `CLEAN`: マージ可能な状態。手順3へ進む。
         - `UNSTABLE`: 必須でないチェックが失敗しているがマージは可能。手順3へ進む。
@@ -112,7 +112,7 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(slee
         - `DIRTY`: コンフリクト解消を試みる。解消できた場合はコミット・プッシュして手順3に戻る（手順7の回数制限の対象）。解消が困難な場合はユーザーに報告し、判断を仰ぐ。
         - `BLOCKED`: 必須チェックまたは必須レビューが未完了。
             - `gh pr view {PR番号} --json reviewDecision --jq '.reviewDecision'` で確認する。
-            - `REVIEW_REQUIRED` の場合: レビュー承認が必要であることをユーザーに報告し、承認を待つか判断を仰ぐ。
+            - `REVIEW_REQUIRED` または `CHANGES_REQUESTED` の場合: レビュー承認が必要、または変更が要求されていることをユーザーに報告し、対応を待つか判断を仰ぐ。
             - それ以外の場合: 手順3に戻りCIの完了を待機する（手順7の回数制限の対象）。
         - `DRAFT`: ドラフトPRである旨をユーザーに報告し、続行するか判断を仰ぐ。
         - `UNKNOWN` または `null`: 10秒待機してから再取得する（最大3回まで）。3回取得しても確定しない場合はユーザーに報告し、判断を仰ぐ。


### PR DESCRIPTION
## 概要

fix-prスキルの `mergeStateStatus` が `BLOCKED` の場合、一律CI待機に進む動作を改善し、`reviewDecision` を確認して `REVIEW_REQUIRED` の場合は早期にユーザーへ報告するようにする。

これにより、レビュー承認待ちの場合に無駄なCI待機・再試行ループを回避できる。

## 関連Issue
Closes #47

## 修正内容
- ステップ2（初回 `mergeStateStatus` 確認）の `BLOCKED` 対応に `reviewDecision` の確認ステップを追加
- ステップ9（マージ前 `mergeStateStatus` 再確認）の `BLOCKED` 対応にも同様の確認ステップを追加
- `REVIEW_REQUIRED` の場合はユーザーに報告し承認を待つか判断を仰ぐ
- それ以外の場合は従来通りCI待機へ進む

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * プルリクエストワークフローの改善: BLOCKED時の処理が明確化され、レビューが必要か変更要求かを判定して「レビュー待ち／変更要求を促す」か「次の手順へ進む」かを分岐するようになりました。BLOCKEDの発生箇所すべてに適用され、必要な承認判定と後続アクションが適切に処理されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->