### PR TITLE
fix(skill): fix-prのreviewDecision確認時にリトライ機構を追加

### DIFF
--- a/plugins/base-tools/skills/fix-pr/SKILL.md
+++ b/plugins/base-tools/skills/fix-pr/SKILL.md
@@ -33,7 +33,11 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(slee
         - `DIRTY`: コンフリクトが存在する。PRブランチへ checkout しベースブランチをマージしてコンフリクト解消を試みる。解消が困難な場合はコンフリクト箇所をユーザーに報告し、判断を仰ぐ。
         - `BLOCKED`: 必須チェックまたは必須レビューが未完了。
             - `gh pr view {PR番号} --json reviewDecision --jq '.reviewDecision'` で確認する。
-            - `REVIEW_REQUIRED` または `CHANGES_REQUESTED` の場合: レビュー承認が必要、または変更が要求されていることをユーザーに報告し、対応を待つか判断を仰ぐ。
+            - `REVIEW_REQUIRED` または `CHANGES_REQUESTED` の場合: GitHub APIのキャッシュにより古い状態が返される可能性があるため、以下のリトライを行う。
+                1. 10秒待機してから `reviewDecision` を再取得する。
+                2. 再取得しても `REVIEW_REQUIRED` または `CHANGES_REQUESTED` のままの場合、再度10秒待機して再取得する。
+                3. リトライは最大3回まで。3回リトライしても状態が変わらない場合、レビュー承認が必要または変更が要求されていることをユーザーに報告し、対応を待つか判断を仰ぐ。
+                4. リトライ中に `APPROVED` 等の別の状態に変わった場合は、手順3へ進む。
             - それ以外の場合: 手順3へ進む。
         - `CLEAN`: マージ可能な状態。手順3へ進む。
         - `UNSTABLE`: 必須でないチェックが失敗しているがマージは可能。手順3へ進む。
@@ -116,7 +120,11 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(slee
         - `DIRTY`: コンフリクト解消を試みる。解消できた場合はコミット・プッシュして手順3に戻る（手順7の回数制限の対象）。解消が困難な場合はユーザーに報告し、判断を仰ぐ。
         - `BLOCKED`: 必須チェックまたは必須レビューが未完了。
             - `gh pr view {PR番号} --json reviewDecision --jq '.reviewDecision'` で確認する。
-            - `REVIEW_REQUIRED` または `CHANGES_REQUESTED` の場合: レビュー承認が必要、または変更が要求されていることをユーザーに報告し、対応を待つか判断を仰ぐ。
+            - `REVIEW_REQUIRED` または `CHANGES_REQUESTED` の場合: GitHub APIのキャッシュにより古い状態が返される可能性があるため、以下のリトライを行う。
+                1. 10秒待機してから `reviewDecision` を再取得する。
+                2. 再取得しても `REVIEW_REQUIRED` または `CHANGES_REQUESTED` のままの場合、再度10秒待機して再取得する。
+                3. リトライは最大3回まで。3回リトライしても状態が変わらない場合、レビュー承認が必要または変更が要求されていることをユーザーに報告し、対応を待つか判断を仰ぐ。
+                4. リトライ中に `APPROVED` 等の別の状態に変わった場合は、手順3に戻りCIの完了を待機する（手順7の回数制限の対象）。
             - それ以外の場合: 手順3に戻りCIの完了を待機する（手順7の回数制限の対象）。
         - `DRAFT`: ドラフトPRである旨をユーザーに報告し、続行するか判断を仰ぐ。
         - `UNKNOWN` または `null`: 10秒待機してから再取得する（最大3回まで）。3回取得しても確定しない場合はユーザーに報告し、判断を仰ぐ。


### PR DESCRIPTION
## 概要

`/fix-pr` スキルで `reviewDecision` を確認した際、GitHub APIのキャッシュにより古い状態が返される問題に対応しました。`BLOCKED` 状態で `REVIEW_REQUIRED` または `CHANGES_REQUESTED` が返された場合、10秒間隔で最大3回のリトライを行い、APIの一時的な遅延による誤判定を回避します。

## 関連Issue

Closes #55

## 修正内容

- 手順2（mergeStateStatus確認時）の `BLOCKED` → `REVIEW_REQUIRED`/`CHANGES_REQUESTED` 判定にリトライ機構を追加
- 手順9（マージ前再確認時）の同箇所にも同様のリトライ機構を追加
- リトライ仕様：
  - 10秒待機してから `reviewDecision` を再取得
  - 最大3回までリトライ
  - リトライ中に状態が変わった場合は次の手順へ進む
  - 3回リトライしても変わらない場合はユーザーに報告

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * プルリクエストレビューの状態確認処理が改善されました。API キャッシュの遅延に対応するため、最大3回までの自動再確認メカニズムが追加されました。再確認時にステータスが更新された場合、ワークフローは自動的に進行します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->