### PR TITLE
feat(skill): fix-prにCodeRabbit rate limit時の再起動手順を追加

### DIFF
--- a/plugins/base-tools/skills/fix-pr/SKILL.md
+++ b/plugins/base-tools/skills/fix-pr/SKILL.md
@@ -51,12 +51,15 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(slee
         - 10秒待機してからリトライする。
         - リトライは最大3回まで。
         - 3回リトライしてもチェックが登録されない場合は、チェック待機をスキップして手順4へ進む（CIが設定されていない、またはトリガー条件に合致しなかったと判断する）。
-    - `gh pr checks --watch` が5分以上経過しても完了しない場合（コマンドがタイムアウトした場合を含む）、CodeRabbit の rate limit による停止を確認する：
-        1. `gh pr checks {PR番号}` で各チェックの状態を確認する。
-        2. CodeRabbit のチェックが `pending` の場合、`gh pr comment {PR番号} --body "@coderabbitai review"` でレビューを再起動する。
-        3. 10分待機してから `gh pr checks {PR番号} --watch` で再度完了を待機する。
-        4. 再度 CodeRabbit が `pending` のままの場合は、手順3-2〜3-3を繰り返す（最大2回まで）。
-        5. 2回リトライしても CodeRabbit が完了しない場合は、CodeRabbit の完了を待たずに手順4へ進む。
+    - CodeRabbit の rate limit による停止に対応するため、`gh pr checks --watch` は5分のタイムアウト付きで実行する：
+        - コマンド: `timeout 300 gh pr checks {PR番号} --watch`
+        - 5分以内に全チェックが完了した場合は手順4へ進む。
+        - 5分経過してもチェックが完了しない場合（`timeout` によりコマンドが終了した場合）、以下の手順で対応する：
+            1. `gh pr checks {PR番号}` で各チェックの状態を確認する。
+            2. CodeRabbit のチェックが `pending` の場合、`gh pr comment {PR番号} --body "@coderabbitai review"` でレビューを再起動する。
+            3. 10分待機してから `timeout 300 gh pr checks {PR番号} --watch` で再度完了を待機する。
+            4. 再度 CodeRabbit が `pending` のままの場合は、手順3-2〜3-3を繰り返す（最大2回まで）。
+            5. 2回リトライしても CodeRabbit が完了しない場合は、CodeRabbit の完了を待たずに手順4へ進む。
 4. CIの結果を確認する。
     - コマンド: `gh pr checks {PR番号}`
     - 一時的な問題（インフラ障害、flaky test等）の場合は `gh run rerun {run-id}` で再実行し、手順3に戻る。同一ワークフローの再実行は最大2回まで。


### PR DESCRIPTION
## 概要

`fix-pr` スキルのCI待機中に、CodeRabbitがrate limitにより`pending`のまま停止した場合に、自動的に`@coderabbitai review`コメントを送信してレビューを再起動する手順を追加しました。

## 関連Issue

Closes #65

## 修正内容

- 手順3（CI待機）に、CodeRabbit rate limit対応の手順を追加
  - `gh pr checks --watch`が5分以上経過しても完了しない場合、CodeRabbitチェックの状態を確認
  - CodeRabbitが`pending`の場合、`@coderabbitai review`コメントでレビューを再起動
  - 10分間隔で最大2回リトライ
  - 2回リトライしても完了しない場合はCodeRabbitの完了を待たずに次の手順へ進む

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * CI チェック待機フェーズでのタイムアウト対応を強化。5 分以上の遅延時に自動リトライ機能を追加し、外部レート制限への対応ロジックを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->