### PR TITLE
feat(skill): fix-prにレビュワーへのapprove依頼プロセスを追加

### DIFF
--- a/plugins/base-tools/skills/fix-pr/SKILL.md
+++ b/plugins/base-tools/skills/fix-pr/SKILL.md
@@ -98,7 +98,8 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(slee
                 - コマンド: `gh pr view {PR番号} --json comments --jq '.comments[].body'` で既存コメントを取得し、「全てのレビューコメントに対応しました。このPRをapproveしてください。」と同一の本文が存在するか確認する。
                 - 投稿済みの場合はapprove依頼コメントを再投稿せずに手順7へ進む。
             2. 未投稿の場合のみ、PRコメントでレビュワーにapproveを依頼する。
-                - コマンド: `gh pr comment {PR番号} --body "全てのレビューコメントに対応しました。このPRをapproveしてください。"`
+                - `gh pr view {PR番号} --json reviews --jq '.reviews[].author.login'` で `CHANGES_REQUESTED` を出したレビュワーを特定し、コメント本文にメンション（`@{レビュワー名}`）を含める。
+                - コマンド: `gh pr comment {PR番号} --body "@{レビュワー名} 全てのレビューコメントに対応しました。このPRをapproveしてください。"`
             3. 60秒待機する。
                 - コマンド: `sleep 60`
             4. `reviewDecision` を再確認する。


### PR DESCRIPTION
## 概要

fix-prスキルでレビュー対応を完了し全スレッドを解決しても、reviewDecisionが`CHANGES_REQUESTED`のままになる問題に対応。レビューコメント把握後にレビュワーへのapprove依頼を行う新ステップを追加し、手動介入なしでPRマージまで完了できるようにする。

## 関連Issue

Closes: #59

## 修正内容

- ステップ5（レビューコメント把握）の後に新しいステップ6（レビュワーへのapprove依頼）を追加
  - 全レビュースレッドが解決済み（`isResolved: true`）かつ`reviewDecision`が`CHANGES_REQUESTED`または`REVIEW_REQUIRED`の場合にPRコメントでapproveを依頼
  - 60秒待機後に`reviewDecision`を再確認
  - レビュースレッドが存在しない場合や未解決スレッドがある場合はスキップ
- 既存ステップ6〜10をステップ7〜11に再番号付け
- 全ての相互参照（手順番号）を正しく更新

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * PRライフサイクル手順を再構成し、承認要求ステップを前倒しで導入、全ステップを再番号化
  * レビューのスレッド確認・解決判定やブロック時の60秒待機を含む拡張リトライ・タイミングロジックを追加
  * マージ方式の優先（squash→merge→rebase）と完了判定・事前チェックの順序を明確化

* **Chores**
  * CI待機・レビュー管理・マージのオーケストレーションフローを更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->