### PR TITLE
chore(plugin): base-toolsプラグインのバージョンを0.0.2に更新

### DIFF
--- a/plugins/base-tools/.claude-plugin/plugin.json
+++ b/plugins/base-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "base-tools",
   "description": "基本ツールプラグイン",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "canpok1"
   }


### PR DESCRIPTION
## 概要
base-toolsプラグインのバージョンを0.0.1から0.0.2に更新します。

## 修正内容
- `plugins/base-tools/.claude-plugin/plugin.json` のversionフィールドを `0.0.1` → `0.0.2` に変更

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)