### PR TITLE
refactor(skill): read-issueのdescriptionを目的文に調整

### DIFF
--- a/plugins/base-tools/skills/read-issue/SKILL.md
+++ b/plugins/base-tools/skills/read-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: read-issue
-description: GitHub Issueの内容を確認する時に使用するスキル。
+description: GitHub Issueの内容（タイトル、本文、ラベル、コメント）を確認し、実装要件を整理する時に使うスキル。
 argument-hint: "[issue-number]"
 allowed-tools: Bash(gh issue view *)
 ---
@@ -8,3 +8,7 @@ allowed-tools: Bash(gh issue view *)
 ## 確認方法
 
 - `gh issue view $ARGUMENTS --comments`
+
+## 注意点
+
+- 確認した内容は、節目ごとに作業メモとして残すこと。要件の整理結果や判断のポイントを記録し、後続の作業で参照できるようにする。


### PR DESCRIPTION
## Summary

- `read-issue`スキルの`description`を目的ベースの文言に調整し、確認対象（タイトル、本文、ラベル、コメント）を明記
- 語尾を他のAtomicスキル（tdd等）と統一（「使用するスキル」→「使うスキル」）
- 注意点セクションに作業メモ記録のルールを追加（ハイブリッド方針対応）

## 変更ファイル

- `plugins/base-tools/skills/read-issue/SKILL.md`

Closes #79

🤖 Generated with [Claude Code](https://claude.ai/code)