### PR TITLE
feat(skill): work-memoスキルを追加

### DIFF
--- a/plugins/base-tools/skills/work-memo/SKILL.md
+++ b/plugins/base-tools/skills/work-memo/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: work-memo
+description: 作業メモファイルの記録・参照を行う時に使うスキル。作業の節目でメモを残したり、過去のメモを参照する場合に使用する。
+agent: general-purpose
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/work-memo/scripts/get-memo-path.sh), Bash(${CLAUDE_PLUGIN_ROOT}/skills/work-memo/scripts/move-memo.sh *), Read, Write, Edit
+---
+
+## メモファイルのパスの取得
+
+現在のブランチに対応するメモファイルのパスを取得する:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/work-memo/scripts/get-memo-path.sh
+```
+
+標準出力に絶対パスを出力する。メモディレクトリは自動作成される。
+ファイルが存在しない場合は、過去のメモがないものとして扱う。
+
+## メモファイルの移動（done/・issued/ へのアーカイブ）
+
+完了・処理済みとなったメモをアーカイブ先へ衝突回避付きで移動する:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/skills/work-memo/scripts/move-memo.sh <src-abs-path> <dest-subdir>
+```
+
+- `<src-abs-path>`: 移動元のメモファイル絶対パス
+- `<dest-subdir>`: `done` または `issued`（`retro` スキルは `done`、`memo-to-issue` スキルは `issued` を指定する）
+- 同名ファイルが既に存在する場合はタイムスタンプ付き（`<basename>.YYYYMMDDHHMMSS.md`）に自動リネームされる
+- 標準出力に移動先の絶対パスが1行出力される
+
+## メモファイルのテンプレート
+
+新規作成時は以下のテンプレートに従う。
+
+```markdown
+# {作業タイトル}
+
+## 目的
+
+{作業の目的を要約}
+
+## 作業内容
+
+- [ ] {タスク1}
+- [ ] {タスク2}
+
+## 作業ログ
+
+### ステップ1: {ステップ名} (YYYY-MM-DD HH:MM)
+- {内容}
+```
+
+## 書き込みルール
+
+- 既存ファイルがある場合は Read で読み取ってから Write で追記する（上書き禁止）
+- 最初に書き込む時は目的・作業内容チェックリストを設定する
+- 各ステップ完了時に作業ログセクションへ追記する
+- 作業内容チェックリストは完了時にチェックを付ける

--- a/plugins/base-tools/skills/work-memo/scripts/get-memo-path.sh
+++ b/plugins/base-tools/skills/work-memo/scripts/get-memo-path.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# 現在のgitブランチに対応する作業メモファイルの絶対パスを出力するスクリプト
+#
+# 使用方法:
+#   ${CLAUDE_PLUGIN_ROOT}/skills/work-memo/scripts/get-memo-path.sh
+#
+# 出力:
+#   メモファイルの絶対パスを標準出力に出力する。
+#   メモディレクトリは必要に応じて自動作成される。
+#   （メモファイル自体は作成しない。存在しない場合もパスだけを返す）
+#
+# メモ保存先:
+#   通常のリポジトリ: {repo}/.tmp/memo/
+#   worktree の場合: {main-repo}/.tmp/memo/
+#
+# 終了コード:
+#   0: 正常完了
+#   1: エラー（gitリポジトリ外など）
+
+set -euo pipefail
+
+BASE_DIR=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)") || {
+    echo "Error: failed to resolve base directory (not a git repository?)" >&2
+    exit 1
+}
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || {
+    echo "Error: failed to get current git branch (not a git repository?)" >&2
+    exit 1
+}
+
+# ブランチ名の /:*?"<>|\ をハイフン - に変換してファイル名として安全な形に正規化
+SANITIZED=$(echo "$BRANCH" | tr '/:*?"<>|\\' '-')
+
+MEMO_DIR="${BASE_DIR}/.tmp/memo"
+MEMO_FILE="${MEMO_DIR}/${SANITIZED}.md"
+
+mkdir -p "$MEMO_DIR"
+
+echo "$MEMO_FILE"

--- a/plugins/base-tools/skills/work-memo/scripts/move-memo.sh
+++ b/plugins/base-tools/skills/work-memo/scripts/move-memo.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# 作業メモファイルをアーカイブ先サブディレクトリへ移動するスクリプト
+#
+# 同名ファイルが既に存在する場合はタイムスタンプ付き（<basename>.YYYYMMDDHHMMSS.md）で
+# リネームして衝突を回避する。
+#
+# メモ保存先:
+#   通常のリポジトリ: {repo}/.tmp/memo/<dest-subdir>/
+#   worktree の場合: {main-repo}/.tmp/memo/<dest-subdir>/
+#
+# 使用方法:
+#   ${CLAUDE_PLUGIN_ROOT}/skills/work-memo/scripts/move-memo.sh <src-abs-path> <dest-subdir>
+#
+# 引数:
+#   <src-abs-path>   移動元のメモファイル絶対パス
+#   <dest-subdir>    メモディレクトリ配下のサブディレクトリ名（例: done, issued）
+#
+# 出力:
+#   移動先の絶対パスを標準出力に1行出力する
+#
+# 終了コード:
+#   0: 正常完了
+#   1: エラー（引数不足、移動元不在など）
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <src-abs-path> <dest-subdir>" >&2
+    exit 1
+fi
+
+SRC=$1
+DEST_SUBDIR=$2
+
+if [[ ! -f "$SRC" ]]; then
+    echo "Error: source file does not exist: $SRC" >&2
+    exit 1
+fi
+
+BASE_DIR=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)") || {
+    echo "Error: failed to resolve base directory (not a git repository?)" >&2
+    exit 1
+}
+
+DEST_DIR="${BASE_DIR}/.tmp/memo/${DEST_SUBDIR}"
+mkdir -p "$DEST_DIR"
+
+BASE=$(basename "$SRC" .md)
+TARGET="${DEST_DIR}/${BASE}.md"
+
+if [[ -e "$TARGET" ]]; then
+    TS=$(date +%Y%m%d%H%M%S)
+    TARGET="${DEST_DIR}/${BASE}.${TS}.md"
+fi
+
+mv "$SRC" "$TARGET"
+echo "$TARGET"


### PR DESCRIPTION
## Summary

- vox-actor版のwork-memoスキルをベースに、base-toolsプラグイン版として `plugins/base-tools/skills/work-memo/` に追加
- メモ保存先の解決ロジックを `WORKSPACE_DIR` 環境変数依存から `git rev-parse --git-common-dir` ベースに変更
- 通常リポジトリとworktreeの両方でメモパスが正しく解決されることを動作確認済み

## 変更内容

- `SKILL.md`: スキル定義（description、allowed-tools、テンプレート、書き込みルール）
- `scripts/get-memo-path.sh`: 現在のブランチに対応するメモファイルパスを出力
- `scripts/move-memo.sh`: メモファイルをdone/issuedサブディレクトリにアーカイブ

## Test plan

- [x] worktreeからの実行でmain repoの `.tmp/memo/` にパスが解決されることを確認
- [x] 通常リポジトリからの実行でリポジトリ直下の `.tmp/memo/` にパスが解決されることを確認
- [x] move-memo.shでメモファイルが正しくアーカイブされることを確認

Closes #84

🤖 Generated with [Claude Code](https://claude.ai/code)