### PR TITLE
fix(script): solve-issue.shのworktreeにissue番号を含めた名前を指定する

### DIFF
--- a/scripts/solve-issue.sh
+++ b/scripts/solve-issue.sh
@@ -57,7 +57,7 @@ git pull origin main
 
 # Claude実行（worktreeモード）
 if [[ "$PRINT_MODE" == "true" ]]; then
-  "${SCRIPT_DIR}/claude-stream.sh" --worktree --dangerously-skip-permissions -p "/base-tools:solve-issue ${ISSUE_NUMBER}"
+  "${SCRIPT_DIR}/claude-stream.sh" --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions -p "/base-tools:solve-issue ${ISSUE_NUMBER}"
 else
-  claude --worktree --dangerously-skip-permissions -p "/base-tools:solve-issue ${ISSUE_NUMBER}"
+  claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions -p "/base-tools:solve-issue ${ISSUE_NUMBER}"
 fi


### PR DESCRIPTION
## Summary

- `scripts/solve-issue.sh` の `--worktree` オプションに `"issue-${ISSUE_NUMBER}"` を指定し、worktree名からどのIssueに対応しているか識別できるようにした
- `claude` 直接実行・`claude-stream.sh` 経由の両方に対応

## Test plan

- [ ] `scripts/solve-issue.sh 123` 実行時に `issue-123` という名前のworktreeが作成されることを確認
- [ ] `scripts/solve-issue.sh -p 456` 実行時に `issue-456` という名前のworktreeが作成されることを確認

Closes #91

🤖 Generated with [Claude Code](https://claude.ai/code)