### PR TITLE
fix(script): solve-issue.shとauto-solve.shの-pオプション周りを修正

### DIFF
--- a/scripts/auto-solve.sh
+++ b/scripts/auto-solve.sh
@@ -3,14 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-PRINT_MODE_FLAG=""
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -p) PRINT_MODE_FLAG="-p"; shift ;;
-    *) echo "Usage: $0 [-p]" >&2; exit 1 ;;
-  esac
-done
+if [[ $# -gt 0 ]]; then
+  echo "Usage: $0" >&2; exit 1
+fi
 
 REPO="$(gh repo view --json nameWithOwner -q '.nameWithOwner')"
 
@@ -33,7 +28,7 @@ while $RUNNING; do
     ISSUE_TITLE=$(echo "$ISSUE" | jq -r '.title')
     echo ""
     echo "#${ISSUE_NUMBER} ${ISSUE_TITLE}"
-    "${SCRIPT_DIR}/solve-issue.sh" $PRINT_MODE_FLAG "$ISSUE_NUMBER" || true
+    "${SCRIPT_DIR}/solve-issue.sh" -p "$ISSUE_NUMBER" || true
   else
     printf "."
   fi

--- a/scripts/solve-issue.sh
+++ b/scripts/solve-issue.sh
@@ -59,5 +59,5 @@ git pull origin main
 if [[ "$PRINT_MODE" == "true" ]]; then
   "${SCRIPT_DIR}/claude-stream.sh" --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions -p "/base-tools:solve-issue ${ISSUE_NUMBER}"
 else
-  claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions -p "/base-tools:solve-issue ${ISSUE_NUMBER}"
+  claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions "/base-tools:solve-issue ${ISSUE_NUMBER}"
 fi


### PR DESCRIPTION
## Summary

- `solve-issue.sh`: `-p`未指定時のelseブランチから`-p`フラグを除去し、`PRINT_MODE`の分岐が正しく機能するように修正
- `auto-solve.sh`: `-p`オプションの引数解析を削除し、常に`-p`付きで`solve-issue.sh`を呼び出すように変更

Closes #95

🤖 Generated with [Claude Code](https://claude.ai/code)