### PR TITLE
feat(skill): work-memoの各ステップログに使用スキルを記録するルールを追加

### DIFF
--- a/plugins/base-tools/skills/work-memo/SKILL.md
+++ b/plugins/base-tools/skills/work-memo/SKILL.md
@@ -69,6 +69,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/work-memo/scripts/move-memo.sh <src-abs-path> analy
 
 ### ステップ1: {ステップ名} (YYYY-MM-DD HH:MM)
 - {内容}
+- 使用スキル: {スキル名1}, {スキル名2}(xN)
 ```
 
 ## 書き込みルール
@@ -77,3 +78,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/work-memo/scripts/move-memo.sh <src-abs-path> analy
 - 最初に書き込む時は目的・作業内容チェックリストを設定する
 - 各ステップ完了時に作業ログセクションへ追記する
 - 作業内容チェックリストは完了時にチェックを付ける
+- 各ステップのログには「使用スキル」行を必ず含め、そのステップで呼び出したスキル名を記録する
+    - プラグイン名のプレフィックス（`base-tools:` 等）は省略し、スキル名のみ記載する
+    - 同一スキルを複数回呼び出した場合は `スキル名(xN)` 形式で回数を付記する（例: `monologue(x3)`）
+    - スキルを呼び出していないステップでは `使用スキル: なし` と記載する


### PR DESCRIPTION
## Summary

- work-memoスキルの書き込みルールを更新し、各ステップの作業ログに「使用スキル」行を必ず含めるルールを追加
- テンプレートのステップログ例にも使用スキル行を追加
- アーカイブ済みメモから呼び出し履歴を後追いで分析できるようにする

### ルールの詳細

- プラグイン名のプレフィックス（`base-tools:` 等）は省略し、スキル名のみ記載
- 同一スキルを複数回呼び出した場合は `スキル名(xN)` 形式で回数を付記（例: `monologue(x3)`）
- スキルを呼び出していないステップでは `使用スキル: なし` と記載

### 対応範囲

Issue #120 では2つの改善が提案されていますが、改善1（PostToolUseフックによる monologue リマインド注入）は `auto-monologue-plugin` で既に対応済みのため、本PRでは改善2のみ対応しています。

Closes #120

🤖 Generated with [Claude Code](https://claude.ai/code)