### PR TITLE
feat(workflow): workflow-scriptsをvox-actorに揃える

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ curl -sL https://raw.githubusercontent.com/canpok1/claude-code-plugins/refs/head
 |-----------|------|
 | `auto-solve.sh` | `assign-to-claude` ラベル付きの Issue を監視し、自動で解決を実行する |
 | `auto-assign.sh` | open Issue を優先度評価し、`assign-to-claude` ラベルを付与する |
+| `auto-analyze.sh` | 完了した作業メモが一定数たまったら自動で分析を実行する |
 | `solve-issue.sh` | 指定した Issue 番号の解決を実行する |
 | `claude-stream.sh` | Claude の出力をストリーミング表示する |
 

--- a/setup-workflow.sh
+++ b/setup-workflow.sh
@@ -8,6 +8,7 @@ DIR="workflow-scripts"
 FILES=(
   "auto-solve.sh"
   "auto-assign.sh"
+  "auto-analyze.sh"
   "solve-issue.sh"
   "claude-stream.sh"
 )

--- a/workflow-scripts/auto-analyze.sh
+++ b/workflow-scripts/auto-analyze.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ $# -ne 1 ]] || ! [[ "$1" =~ ^[0-9]+$ ]] || [[ "$1" -eq 0 ]]; then
+  echo "Usage: $0 <min-count>" >&2
+  exit 1
+fi
+
+MIN_COUNT="$1"
+
+LOCK_DIR="${WORKSPACE_DIR}/.tmp/locks"
+mkdir -p "$LOCK_DIR"
+lock_file="${LOCK_DIR}/auto-analyze"
+
+exec 9>"$lock_file"
+if ! flock -n 9; then
+  echo "auto-analyze is already running"
+  exit 1
+fi
+
+trap 'echo ""; echo "Shutting down..."; exit 0' SIGINT SIGTERM
+
+MEMO_DONE_DIR="${WORKSPACE_DIR}/.tmp/memo/done"
+
+echo "Watching ${MEMO_DONE_DIR} (min-count: ${MIN_COUNT})..."
+
+PREV_STATE=""
+
+while true; do
+  if [[ -d "$MEMO_DONE_DIR" ]]; then
+    FILE_COUNT=$(( $(find "$MEMO_DONE_DIR" -maxdepth 1 -type f | wc -l) ))
+  else
+    FILE_COUNT=0
+  fi
+
+  if [[ "$FILE_COUNT" -ge "$MIN_COUNT" ]]; then
+    CURRENT_STATE="analyzing"
+    echo ""
+    echo "File count: ${FILE_COUNT} (>= ${MIN_COUNT}), starting analyze-work-memo..."
+
+    "${SCRIPT_DIR}/claude-stream.sh" -p "/base-tools:analyze-work-memo"
+  else
+    CURRENT_STATE="waiting"
+    if [[ "$PREV_STATE" != "$CURRENT_STATE" ]]; then
+      echo ""
+      echo "File count: ${FILE_COUNT} (< ${MIN_COUNT}), waiting..."
+    else
+      printf "."
+    fi
+  fi
+
+  PREV_STATE="$CURRENT_STATE"
+  sleep 60
+done

--- a/workflow-scripts/auto-assign.sh
+++ b/workflow-scripts/auto-assign.sh
@@ -93,7 +93,7 @@ while $RUNNING; do
       echo ""
       echo "Queue: ${QUEUE_COUNT} (< ${MIN_QUEUE}), assigning..."
 
-      "${SCRIPT_DIR}/claude-stream.sh" -p "/base-tools:assign-issues --count ${ASSIGN_COUNT}" || true
+      "${SCRIPT_DIR}/claude-stream.sh" -p "/base-tools:assign-issues --count ${ASSIGN_COUNT}"
     fi
   fi
 

--- a/workflow-scripts/auto-solve.sh
+++ b/workflow-scripts/auto-solve.sh
@@ -28,7 +28,7 @@ while $RUNNING; do
     ISSUE_TITLE=$(echo "$ISSUE" | jq -r '.title')
     echo ""
     echo "#${ISSUE_NUMBER} ${ISSUE_TITLE}"
-    "${SCRIPT_DIR}/solve-issue.sh" -p "$ISSUE_NUMBER" || true
+    "${SCRIPT_DIR}/solve-issue.sh" -p "$ISSUE_NUMBER"
   else
     printf "."
   fi

--- a/workflow-scripts/claude-stream.sh
+++ b/workflow-scripts/claude-stream.sh
@@ -1,7 +1,69 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-claude "$@" --output-format stream-json --verbose --include-partial-messages \
-  | jq -rj 'if .type == "text_delta" then .text elif .type == "result" then .result else empty end'
+claude "$@" --output-format stream-json --verbose --include-partial-messages -p \
+  | jq -nrj --unbuffered '
+    def oneline: gsub("\n"; " ⏎ ");
+    def trunc($n): if length > $n then .[0:$n] + "…" else . end;
+
+    foreach inputs as $x (
+      {ic: 0};
+
+      # state update: track cumulative tool-input bytes within a tool_use block
+      if   $x.type == "stream_event"
+           and $x.event.type == "content_block_start"
+           and $x.event.content_block.type == "tool_use" then .ic = 0
+      elif $x.type == "stream_event"
+           and ($x.event.delta.type // "") == "input_json_delta" then
+        .ic += ($x.event.delta.partial_json | length)
+      else . end;
+
+      . as $s |
+      ( if $x.type == "stream_event" then
+          $x.event as $e |
+          if $e.type == "content_block_start" then
+            $e.content_block as $cb |
+            if   $cb.type == "tool_use"  then "\n[tool_use: \($cb.name)] "
+            elif $cb.type == "thinking"  then "\n[thinking]"
+            elif $cb.type == "text"      then "\n[text]\n"
+            else "" end
+          elif $e.type == "content_block_delta" then
+            $e.delta as $d |
+            if   $d.type == "text_delta"     then $d.text
+            elif $d.type == "input_json_delta" then
+              ($s.ic - ($d.partial_json | length)) as $prev |
+              if $prev >= 80 then ""
+              else
+                ($d.partial_json | .[0 : 80 - $prev]) as $emit |
+                (if $s.ic > 80 and $prev < 80 then $emit + "…" else $emit end)
+              end
+            else "" end
+          elif $e.type == "content_block_stop" then ""
+          elif $e.type == "message_stop"       then ""
+          else "" end
+
+        elif $x.type == "user" then
+          ($x.message.content[0] // {}) as $c |
+          if $c.type == "tool_result" then
+            ( $c.content
+              | if   type == "string" then .
+                elif type == "array"  then map(.text // tostring) | join(" ")
+                else tostring end
+              | oneline | trunc(100)
+            ) as $body |
+            "\n[tool_result] \($body)"
+          else "" end
+
+        elif $x.type == "system" then
+          if   $x.subtype == "init"         then "[init session: \($x.model // "")]"
+          elif $x.subtype == "notification" then "\n[notification]"
+          else "" end
+
+        elif $x.type == "rate_limit_event" then "\n[rate_limit]"
+        elif $x.type == "result"           then "\n--- result ---\n" + ($x.result // "")
+        else "" end
+      )
+    )
+  '
 
 echo

--- a/workflow-scripts/solve-issue.sh
+++ b/workflow-scripts/solve-issue.sh
@@ -57,7 +57,7 @@ git pull origin main
 
 # Claude実行（worktreeモード）
 if [[ "$PRINT_MODE" == "true" ]]; then
-  "${SCRIPT_DIR}/claude-stream.sh" --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions -p "/base-tools:solve-issue ${ISSUE_NUMBER}"
+  "${SCRIPT_DIR}/claude-stream.sh" --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions --model sonnet -p "/base-tools:solve-issue ${ISSUE_NUMBER}"
 else
-  claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions "/base-tools:solve-issue ${ISSUE_NUMBER}"
+  claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions --model sonnet "/base-tools:solve-issue ${ISSUE_NUMBER}"
 fi


### PR DESCRIPTION
## 概要

canpok1/vox-actor の workflow-scripts に内容を揃えました。

## 変更内容

- `auto-analyze.sh` を新規追加（作業メモが一定数たまったら自動分析を実行）
- `auto-assign.sh` / `auto-solve.sh` の呼び出しから `|| true` を削除
- `claude-stream.sh` を stream-json 詳細整形版へ置き換え
- `solve-issue.sh` の claude 起動に `--model sonnet` を追加
- `setup-workflow.sh` と README に `auto-analyze.sh` を反映

## 確認事項

- 既存コミット 497c8ab をベースに作成しています
- 新規にコミットすべきローカル変更はありません（未追跡ファイルは worktree と devcontainer-lock のみでコミット対象外）

🤖 Generated with [Claude Code](https://claude.ai/code)